### PR TITLE
feat: add support for non-iOS platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "ObservableArray",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,3 +1,4 @@
+#if !os(watchOS)
 import XCTest
 
 import ObservableArrayTests
@@ -5,3 +6,4 @@ import ObservableArrayTests
 var tests = [XCTestCaseEntry]()
 tests += ObservableArrayTests.allTests()
 XCTMain(tests)
+#endif

--- a/Tests/ObservableArrayTests/ObservableArrayTests.swift
+++ b/Tests/ObservableArrayTests/ObservableArrayTests.swift
@@ -1,4 +1,6 @@
+#if !os(watchOS)
 import XCTest
+
 @testable import ObservableArray
 
 final class ObservableArrayTests: XCTestCase {
@@ -6,3 +8,4 @@ final class ObservableArrayTests: XCTestCase {
         
     ]
 }
+#endif

--- a/Tests/ObservableArrayTests/XCTestManifests.swift
+++ b/Tests/ObservableArrayTests/XCTestManifests.swift
@@ -1,3 +1,4 @@
+#if !os(watchOS)
 import XCTest
 
 #if !canImport(ObjectiveC)
@@ -6,4 +7,5 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(observable_arrayTests.allTests),
     ]
 }
+#endif
 #endif


### PR DESCRIPTION
Manual action: new release drop after merge

Motivation: this change is a prerequisite to make [cloud-sdk-ios-fiori](https://github.com/SAP/cloud-sdk-ios-fiori) available for more platforms, i.e macOS